### PR TITLE
New esphome update 2023.11.2 complains about this

### DIFF
--- a/esphome/board-esp32-wemos-s3.yaml
+++ b/esphome/board-esp32-wemos-s3.yaml
@@ -19,7 +19,6 @@ i2c:
 esphome:
   platformio_options:
     board_build.arduino.memory_type: qio_qspi
-    board_upload.flash_size: 4MB
     board_upload.ram_size: 327680
     board_upload_maximum_size: 4193404
     board_upload_speed: 460800

--- a/esphome/board-esp32-wemos-s3.yaml
+++ b/esphome/board-esp32-wemos-s3.yaml
@@ -6,6 +6,7 @@ esp32:
   framework:
     type: arduino
 #    version: latest
+  flash_size: 4MB
 
 # the m5stack TOF sensor vl53l0x is I2C
 i2c:  


### PR DESCRIPTION
Please specify flash_size within esp32 configuration only