### PR TITLE
Make remianing capacity more accurate

### DIFF
--- a/esphome/board-esp32-wemos-s3.yaml
+++ b/esphome/board-esp32-wemos-s3.yaml
@@ -74,7 +74,7 @@ binary_sensor:
         - sensor.template.publish:
             id: clack_watermeter
             state: !lambda |-
-              return id(totalWaterUsage) += 2;
+              return id(totalWaterUsage) += 2.2;
         - sensor.template.publish:
             id: clack_m3_left
             state: !lambda |-
@@ -138,7 +138,7 @@ button:
         - sensor.template.publish:
             id: clack_watermeter
             state: !lambda |-
-              return id(totalWaterUsage) += 2;
+              return id(totalWaterUsage) += 2.2;
         - sensor.template.publish:
             id: clack_m3_left
             state: !lambda |-

--- a/esphome/clack.yaml
+++ b/esphome/clack.yaml
@@ -296,7 +296,7 @@ sensor:
     unit_of_measurement: L
     device_class: water
     state_class: total_increasing
-    accuracy_decimals: 0
+    accuracy_decimals: 2
     lambda: |-
       return id(totalWaterUsage);
 
@@ -313,7 +313,7 @@ sensor:
     name: ${clack_l_left}
     unit_of_measurement: L
     device_class: water
-    accuracy_decimals: 0
+    accuracy_decimals: 2
     update_interval: ${watermeter_update_interval}
 
 switch:


### PR DESCRIPTION
Before this, the valve always showed less capacity remaining than the clack reader. This makes it very close. After this, usually there is no difference, or a difference of 0.01m3.